### PR TITLE
 Migrations: Add in progress data to migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+**When upgrading to this version of hsd, you must pass `--chain-migrate=4`
+and `--wallet-migrate=6` when you run it for the first time.**
+
 ### Wallet Changes
 
 #### Wallet HTTP API

--- a/lib/blockchain/migrations.js
+++ b/lib/blockchain/migrations.js
@@ -533,6 +533,45 @@ class MigrateTreeState extends AbstractMigration {
   }
 }
 
+class MigrateMigrationStateV1 extends AbstractMigration {
+  /**
+   * Create migration migration state
+   * @constructor
+   * @param {ChainMigratorOptions} options
+   */
+
+  constructor(options) {
+    super(options);
+
+    this.options = options;
+    this.logger = options.logger.context('chain-migration-migration-state-v1');
+    this.db = options.db;
+    this.ldb = options.ldb;
+    this.network = options.network;
+  }
+
+  async check() {
+    return types.MIGRATE;
+  }
+
+  /**
+   * @param {Batch} b
+   * @param {MigrationContext} ctx
+   * @returns {Promise}
+   */
+
+  async migrate(b, ctx) {
+    ctx.state.version = 1;
+  }
+
+  static info() {
+    return {
+      name: 'Migrate Migration State',
+      description: 'Migrate migration state to v1'
+    };
+  }
+}
+
 /**
  * Chain Migrator
  * @alias module:blockchain.ChainMigrator
@@ -550,8 +589,6 @@ class ChainMigrator extends Migrator {
     this.logger = this.options.logger.context('chain-migrations');
     this.flagError = 'Restart with `hsd --chain-migrate='
       + this.lastMigration + '`';
-
-    this._migrationsToRun = null;
   }
 
   /**
@@ -673,7 +710,8 @@ ChainMigrator.migrations = {
   0: MigrateMigrations,
   1: MigrateChainState,
   2: MigrateBlockStore,
-  3: MigrateTreeState
+  3: MigrateTreeState,
+  4: MigrateMigrationStateV1
 };
 
 // Expose migrations
@@ -681,5 +719,6 @@ ChainMigrator.MigrateChainState = MigrateChainState;
 ChainMigrator.MigrateMigrations = MigrateMigrations;
 ChainMigrator.MigrateBlockStore = MigrateBlockStore;
 ChainMigrator.MigrateTreeState = MigrateTreeState;
+ChainMigrator.MigrateMigrationStateV1 = MigrateMigrationStateV1;
 
 module.exports = ChainMigrator;

--- a/lib/blockchain/migrations.js
+++ b/lib/blockchain/migrations.js
@@ -18,15 +18,17 @@ const CoinView = require('../coins/coinview');
 const UndoCoins = require('../coins/undocoins');
 const layout = require('./layout');
 const AbstractMigration = require('../migrations/migration');
+const migrator = require('../migrations/migrator');
 const {
   Migrator,
   oldLayout,
   types
-} = require('../migrations/migrator');
+} = migrator;
 
 /** @typedef {import('../types').Hash} Hash */
 /** @typedef {ReturnType<bdb.DB['batch']>} Batch */
-/** @typedef {import('../migrations/migrator').types} MigrationType */
+/** @typedef {migrator.types} MigrationType */
+/** @typedef {migrator.MigrationContext} MigrationContext */
 
 /**
  * Switch to new migrations layout.
@@ -59,14 +61,14 @@ class MigrateMigrations extends AbstractMigration {
   /**
    * Actual migration
    * @param {Batch} b
+   * @param {MigrationContext} ctx
    * @returns {Promise}
    */
 
-  async migrate(b) {
+  async migrate(b, ctx) {
     this.logger.info('Migrating migrations..');
 
     const oldLayout = this.layout.oldLayout;
-    const newLayout = this.layout.newLayout;
     let nextMigration = 1;
     const skipped = [];
 
@@ -90,33 +92,9 @@ class MigrateMigrations extends AbstractMigration {
 
     this.db.writeVersion(b, 2);
 
-    const rawState = this.encodeMigrationState(nextMigration, skipped);
-    b.put(newLayout.M.encode(), rawState);
-  }
-
-  /**
-   * @param {Number} nextMigration
-   * @param {Number[]} skipped
-   * @returns {Buffer}
-   */
-
-  encodeMigrationState(nextMigration, skipped) {
-    let size = 4;
-    size += encoding.sizeVarint(nextMigration);
-    size += encoding.sizeVarint(skipped.length);
-
-    for (const id of skipped)
-      size += encoding.sizeVarint(id);
-
-    const bw = bio.write(size);
-    bw.writeU32(0);
-    bw.writeVarint(nextMigration);
-    bw.writeVarint(skipped.length);
-
-    for (const id of skipped)
-      bw.writeVarint(id);
-
-    return bw.render();
+    ctx.state.version = 0;
+    ctx.state.skipped = skipped;
+    ctx.state.nextMigration = nextMigration;
   }
 
   static info() {

--- a/lib/migrations/migration.js
+++ b/lib/migrations/migration.js
@@ -8,6 +8,7 @@
 /** @typedef {import('bdb').DB} DB */
 /** @typedef {ReturnType<DB['batch']>} Batch */
 /** @typedef {import('./migrator').types} MigrationType */
+/** @typedef {import('./migrator').MigrationContext} MigrationContext */
 
 /**
  * Abstract class for single migration.
@@ -37,10 +38,11 @@ class AbstractMigration {
   /**
    * Run the actual migration
    * @param {Batch} b
+   * @param {MigrationContext} [ctx]
    * @returns {Promise}
    */
 
-  async migrate(b) {
+  async migrate(b, ctx) {
     throw new Error('Abstract method.');
   }
 

--- a/lib/migrations/migration.js
+++ b/lib/migrations/migration.js
@@ -38,7 +38,7 @@ class AbstractMigration {
   /**
    * Run the actual migration
    * @param {Batch} b
-   * @param {MigrationContext} [ctx]
+   * @param {MigrationContext} ctx
    * @returns {Promise}
    */
 

--- a/lib/migrations/migrator.js
+++ b/lib/migrations/migrator.js
@@ -13,6 +13,7 @@ const MigrationState = require('../migrations/state');
 
 /** @typedef {ReturnType<bdb.DB['batch']>} Batch */
 /** @typedef {import('../blockchain/chaindb')} ChainDB */
+/** @typedef {import('../wallet/walletdb')} WalletDB */
 
 const EMPTY = Buffer.alloc(0);
 
@@ -67,9 +68,9 @@ class Migrator {
     this.migrateFlag = -1;
 
     this.layout = migrationLayout;
-    /** @type {ChainDB} */
+    /** @type {ChainDB|WalletDB|null} */
     this.db = null;
-    /** @type {bdb.DB} */
+    /** @type {bdb.DB?} */
     this.ldb = null;
     this.dbVersion = 0;
 

--- a/lib/migrations/migrator.js
+++ b/lib/migrations/migrator.js
@@ -1,6 +1,7 @@
 /**
  * migrations/migrator.js - abstract migrator for hsd.
  * Copyright (c) 2021, Nodari Chkuaselidze (MIT License)
+ * https://github.com/handshake-org/hsd
  */
 
 'use strict';
@@ -12,6 +13,8 @@ const MigrationState = require('../migrations/state');
 
 /** @typedef {ReturnType<bdb.DB['batch']>} Batch */
 /** @typedef {import('../blockchain/chaindb')} ChainDB */
+
+const EMPTY = Buffer.alloc(0);
 
 /**
  * This entry needs to be part of all dbs that support migrations.
@@ -43,36 +46,6 @@ const types = {
   SKIP: 1,
   FAKE_MIGRATE: 2
 };
-
-/**
- * Store migration results.
- * @alias module:migrations.MigrationResult
- */
-
-class MigrationResult {
-  constructor() {
-    /** @type {Set<Number>} */
-    this.migrated = new Set();
-    /** @type {Set<Number>} */
-    this.skipped = new Set();
-  }
-
-  /**
-   * @param {Number} id
-   */
-
-  skip(id) {
-    this.skipped.add(id);
-  }
-
-  /**
-   * @param {Number} id
-   */
-
-  migrate(id) {
-    this.migrated.add(id);
-  }
-}
 
 /**
  * class for migrations.
@@ -220,12 +193,15 @@ class Migrator {
           this.logger.info('Migration %d in progress...', id);
           const batch = this.ldb.batch();
 
-          // queue state updates first, so migration can modify the state.
+          const context = this.createContext(state);
+          await currentMigration.migrate(batch, context);
+
+          // allow migrations to increment next migration
+          state.nextMigration = Math.max(state.nextMigration, id + 1);
           state.inProgress = false;
-          state.nextMigration = id + 1;
+          state.inProgressData = EMPTY;
           this.writeState(batch, state);
 
-          await currentMigration.migrate(batch, this.pending);
           await batch.write();
           this.pending.migrate(id);
           this.logger.info('Migration %d is done.', id);
@@ -395,9 +371,72 @@ class Migrator {
     assert(data, 'State was corrupted.');
     return MigrationState.decode(data);
   }
+
+  /**
+   * Create context
+   * @param {MigrationState} state
+   * @returns {MigrationContext}
+   */
+
+  createContext(state) {
+    return new MigrationContext(this, state, this.pending);
+  }
+}
+
+/**
+ * Store migration results.
+ * @alias module:migrations.MigrationResult
+ */
+
+class MigrationResult {
+  constructor() {
+    /** @type {Set<Number>} */
+    this.migrated = new Set();
+    /** @type {Set<Number>} */
+    this.skipped = new Set();
+  }
+
+  /**
+   * @param {Number} id
+   */
+
+  skip(id) {
+    this.skipped.add(id);
+  }
+
+  /**
+   * @param {Number} id
+   */
+
+  migrate(id) {
+    this.migrated.add(id);
+  }
+}
+
+/**
+ * Migration Context.
+ */
+
+class MigrationContext {
+  /**
+   * @param {Migrator} migrator
+   * @param {MigrationState} state
+   * @param {MigrationResult} pending
+   */
+
+  constructor(migrator, state, pending) {
+    this.migrator = migrator;
+    this.state = state;
+    this.pending = pending;
+  }
+
+  async saveState() {
+    await this.migrator.saveState(this.state);
+  }
 }
 
 exports.Migrator = Migrator;
 exports.MigrationResult = MigrationResult;
+exports.MigrationContext = MigrationContext;
 exports.types = types;
 exports.oldLayout = oldLayout;

--- a/lib/migrations/migrator.js
+++ b/lib/migrations/migrator.js
@@ -11,6 +11,7 @@ const bdb = require('bdb');
 const MigrationState = require('../migrations/state');
 
 /** @typedef {ReturnType<bdb.DB['batch']>} Batch */
+/** @typedef {import('../blockchain/chaindb')} ChainDB */
 
 /**
  * This entry needs to be part of all dbs that support migrations.
@@ -93,7 +94,9 @@ class Migrator {
     this.migrateFlag = -1;
 
     this.layout = migrationLayout;
+    /** @type {ChainDB} */
     this.db = null;
+    /** @type {bdb.DB} */
     this.ldb = null;
     this.dbVersion = 0;
 
@@ -152,45 +155,22 @@ class Migrator {
 
   /**
    * Do the actual migrations
-   * @returns {Promise}
+   * @returns {Promise<MigrationResult>}
    */
 
   async migrate() {
     const version = await this.ldb.get(this.layout.V.encode());
     const lastID = this.getLastMigrationID();
 
-    if (version === null) {
-      if (this.migrateFlag !== -1) {
-        if (this.migrateFlag !== lastID) {
-          throw new Error(
-            `Migrate flag ${this.migrateFlag} does not match last ID: ${lastID}`
-          );
-        }
-
-        this.logger.warning('Fresh start, ignoring migration flag.');
-      }
-
-      const state = new MigrationState();
-      state.nextMigration = this.getLastMigrationID() + 1;
-
-      this.logger.info('Fresh start, saving last migration id: %d',
-        state.lastMigration);
-
-      await this.saveState(state);
-      return this.pending;
-    }
+    if (version === null)
+      return this.initialize();
 
     await this.ensure();
     await this.verifyDB();
     await this.checkMigrations();
+    this.checkMigrateFlag();
 
     let state = await this.getState();
-
-    if (this.migrateFlag !== -1 && this.migrateFlag !== lastID) {
-      throw new Error(
-        `Migrate flag ${this.migrateFlag} does not match last ID: ${lastID}`
-      );
-    }
 
     this.logger.debug('Last migration %d, last available migration: %d',
       state.lastMigration, lastID);
@@ -292,6 +272,45 @@ class Migrator {
     }
 
     this.logger.info(error);
+  }
+
+  /**
+   * Check migration flags.
+   * @throws {Error}
+   */
+
+  checkMigrateFlag() {
+    if (this.migrateFlag === -1)
+      return;
+
+    const lastID = this.getLastMigrationID();
+
+    if (this.migrateFlag !== lastID) {
+      throw new Error(
+        `Migrate flag ${this.migrateFlag} does not match last ID: ${lastID}`);
+    }
+  }
+
+  /**
+   * Init fresh db.
+   * @returns {Promise<MigrationResult>}
+   */
+
+  async initialize() {
+    this.checkMigrateFlag();
+
+    if (this.migrateFlag !== -1)
+      this.logger.warning('Fresh start, ignoring migration flag.');
+
+    const state = new MigrationState();
+    state.nextMigration = this.getLastMigrationID() + 1;
+
+    this.logger.info('Fresh start, saving last migration id: %d',
+      state.lastMigration);
+
+    await this.saveState(state);
+
+    return this.pending;
   }
 
   /**

--- a/lib/migrations/state.js
+++ b/lib/migrations/state.js
@@ -10,6 +10,8 @@ const {encoding} = bio;
 
 /** @typedef {import('../types').BufioWriter} BufioWriter */
 
+const EMPTY = Buffer.alloc(0);
+
 /**
  * State of database migrations.
  * Because migration IDs are only increasing, we only need
@@ -32,10 +34,13 @@ class MigrationState extends bio.Struct {
   constructor() {
     super();
 
+    this.version = 1;
     this.inProgress = false;
     this.nextMigration = 0;
     /** @type {Number[]} */
     this.skipped = [];
+
+    this.inProgressData = EMPTY;
   }
 
   get lastMigration() {
@@ -62,13 +67,16 @@ class MigrationState extends bio.Struct {
    */
 
   getSize() {
-    // flags + last migration number
-    let size = 4; // flags
+    let size = 2; // flags
+    size += 2; // version
     size += encoding.sizeVarint(this.nextMigration);
     size += encoding.sizeVarint(this.skipped.length);
 
     for (const id of this.skipped)
       size += encoding.sizeVarint(id);
+
+    if (this.version > 0)
+      size += encoding.sizeVarBytes(this.inProgressData);
 
     return size;
   }
@@ -85,12 +93,16 @@ class MigrationState extends bio.Struct {
     if (this.inProgress)
       flags |= 1 << 0;
 
-    bw.writeU32(flags);
+    bw.writeU16(flags);
+    bw.writeU16(this.version);
     bw.writeVarint(this.nextMigration);
     bw.writeVarint(this.skipped.length);
 
     for (const id of this.skipped)
       bw.writeVarint(id);
+
+    if (this.version > 0)
+      bw.writeVarBytes(this.inProgressData);
 
     return bw;
   }
@@ -102,9 +114,10 @@ class MigrationState extends bio.Struct {
    */
 
   read(br) {
-    const flags = br.readU32();
-
+    const flags = br.readU16();
     this.inProgress = (flags & 1) !== 0;
+
+    this.version = br.readU16();
     this.nextMigration = br.readVarint();
     this.skipped = [];
 
@@ -112,6 +125,9 @@ class MigrationState extends bio.Struct {
 
     for (let i = 0; i < skippedItems; i++)
       this.skipped.push(br.readVarint());
+
+    if (this.version > 0)
+      this.inProgressData = br.readVarBytes();
 
     return this;
   }

--- a/lib/migrations/state.js
+++ b/lib/migrations/state.js
@@ -58,6 +58,7 @@ class MigrationState extends bio.Struct {
     this.inProgress = obj.inProgress;
     this.nextMigration = obj.nextMigration;
     this.skipped = obj.skipped.slice();
+    this.inProgressData = obj.inProgressData.slice();
     return this;
   }
 

--- a/lib/wallet/migrations.js
+++ b/lib/wallet/migrations.js
@@ -26,16 +26,19 @@ const WalletKey = require('./walletkey');
 const Path = require('./path');
 const MapRecord = require('./records').MapRecord;
 const AbstractMigration = require('../migrations/migration');
+const migrator = require('../migrations/migrator');
 const {
   MigrationResult,
+  MigrationContext,
   Migrator,
   types,
   oldLayout
-} = require('../migrations/migrator');
+} = migrator;
 const layouts = require('./layout');
 const wlayout = layouts.wdb;
 
-/** @typedef {import('../migrations/migrator').types} MigrationType */
+/** @typedef {migrator.types} MigrationType */
+/** @typedef {import('../migrations/state')} MigrationState */
 /** @typedef {ReturnType<bdb.DB['batch']>} Batch */
 /** @typedef {ReturnType<bdb.DB['bucket']>} Bucket */
 /** @typedef {import('./walletdb')} WalletDB */
@@ -74,10 +77,11 @@ class MigrateMigrations extends AbstractMigration {
   /**
    * Actual migration
    * @param {Batch} b
+   * @param {WalletMigrationContext} ctx
    * @returns {Promise}
    */
 
-  async migrate(b) {
+  async migrate(b, ctx) {
     this.logger.info('Migrating migrations..');
     let nextMigration = 1;
 
@@ -87,24 +91,9 @@ class MigrateMigrations extends AbstractMigration {
     }
 
     this.db.writeVersion(b, 1);
-    b.put(
-      this.layout.newLayout.wdb.M.encode(),
-      this.encodeMigrationState(nextMigration)
-    );
-  }
 
-  /**
-   * @param {Number} nextMigration
-   * @returns {Buffer}
-   */
-
-  encodeMigrationState(nextMigration) {
-    const size = 4 + 1 + 1;
-    const encoded = Buffer.alloc(size);
-
-    encoding.writeVarint(encoded, nextMigration, 4);
-
-    return encoded;
+    ctx.state.version = 0;
+    ctx.state.nextMigration = nextMigration;
   }
 
   static info() {
@@ -166,11 +155,11 @@ class MigrateChangeAddress extends AbstractMigration {
   /**
    * Actual migration
    * @param {Batch} b
-   * @param {WalletMigrationResult} [pending]
+   * @param {WalletMigrationContext} ctx
    * @returns {Promise}
    */
 
-  async migrate(b, pending) {
+  async migrate(b, ctx) {
     const wlayout = this.layout.wdb;
     const wids = await this.ldb.keys({
       gte: wlayout.W.min(),
@@ -185,7 +174,7 @@ class MigrateChangeAddress extends AbstractMigration {
     }
 
     if (total > 0)
-      pending.rescan = true;
+      ctx.pending.rescan = true;
   }
 
   /**
@@ -520,12 +509,12 @@ class MigrateTXDBBalances extends AbstractMigration {
   /**
    * Actual migration
    * @param {Batch} b
-   * @param {WalletMigrationResult} [pending]
+   * @param {WalletMigrationContext} [ctx]
    * @returns {Promise}
    */
 
-  async migrate(b, pending) {
-    pending.recalculateTXDB = true;
+  async migrate(b, ctx) {
+    ctx.pending.recalculateTXDB = true;
   }
 
   static info() {
@@ -1332,6 +1321,22 @@ class WalletMigrationResult extends MigrationResult {
 }
 
 /**
+ * @alias module:blockchain.WalletMigrationContext
+ */
+
+class WalletMigrationContext extends MigrationContext {
+  /**
+   * @param {WalletMigrator} migrator
+   * @param {MigrationState} state
+   * @param {WalletMigrationResult} pending
+   */
+
+  constructor(migrator, state, pending) {
+    super(migrator, state, pending);
+  }
+}
+
+/**
  * Wallet Migrator
  * @alias module:blockchain.WalletMigrator
  */
@@ -1374,6 +1379,15 @@ class WalletMigrator extends Migrator {
       ids.delete(1);
 
     return ids;
+  }
+
+  /**
+   * @param {MigrationState} state
+   * @returns {WalletMigrationContext}
+   */
+
+  createContext(state) {
+    return new WalletMigrationContext(this, state, this.pending);
   }
 }
 

--- a/lib/wallet/migrations.js
+++ b/lib/wallet/migrations.js
@@ -60,7 +60,7 @@ class MigrateMigrations extends AbstractMigration {
 
     /** @type {WalletMigratorOptions} */
     this.options = options;
-    this.logger = options.logger.context('wallet-migrations-migrate');
+    this.logger = options.logger.context('wallet-migration-migrate');
     this.db = options.db;
     this.ldb = options.ldb;
     this.layout = MigrateMigrations.layout();
@@ -136,7 +136,7 @@ class MigrateChangeAddress extends AbstractMigration {
 
     /** @type {WalletMigratorOptions} */
     this.options = options;
-    this.logger = options.logger.context('change-address-migration');
+    this.logger = options.logger.context('wallet-migration-change-address');
     this.db = options.db;
     this.ldb = options.ldb;
     this.layout = MigrateChangeAddress.layout();
@@ -381,7 +381,7 @@ class MigrateAccountLookahead extends AbstractMigration {
 
     /** @type {WalletMigratorOptions} */
     this.options = options;
-    this.logger = options.logger.context('account-lookahead-migration');
+    this.logger = options.logger.context('wallet-migration-account-lookahead');
     this.db = options.db;
     this.ldb = options.ldb;
     this.layout = MigrateAccountLookahead.layout();
@@ -492,7 +492,7 @@ class MigrateTXDBBalances extends AbstractMigration {
 
     /** @type {WalletMigratorOptions} */
     this.options = options;
-    this.logger = options.logger.context('txdb-balance-migration');
+    this.logger = options.logger.context('wallet-migration-txdb-balance');
     this.db = options.db;
     this.ldb = options.ldb;
   }
@@ -552,7 +552,7 @@ class MigrateBidRevealEntries extends AbstractMigration {
 
     /** @type {WalletMigratorOptions} */
     this.options = options;
-    this.logger = options.logger.context('bid-reveal-entries-migration');
+    this.logger = options.logger.context('wallet-migration-bid-reveal-entries');
     this.db = options.db;
     this.ldb = options.ldb;
     this.layout = MigrateBidRevealEntries.layout();
@@ -788,7 +788,8 @@ class MigrateTXCountTimeIndex extends AbstractMigration {
 
     /** @type {WalletMigratorOptions} */
     this.options = options;
-    this.logger = options.logger.context('tx-count-time-index-migration');
+    this.logger = options.logger.context(
+      'wallet-migration-tx-count-time-index');
     this.db = options.db;
     this.ldb = options.ldb;
     this.layout = MigrateTXCountTimeIndex.layout();
@@ -1306,6 +1307,51 @@ class MigrateTXCountTimeIndex extends AbstractMigration {
   }
 }
 
+class MigrateMigrationStateV1 extends AbstractMigration {
+  /**
+   * Create Migration State migration object.
+   * @param {WalletMigratorOptions} options
+   * @constructor
+   */
+
+  constructor(options) {
+    super(options);
+
+    /** @type {WalletMigratorOptions} */
+    this.options = options;
+    this.logger = options.logger.context('wallet-migration-migration-state-v1');
+    this.db = options.db;
+    this.ldb = options.ldb;
+  }
+
+  /**
+   * We always migrate.
+   * @returns {Promise<MigrationType>}
+   */
+
+  async check() {
+    return types.MIGRATE;
+  }
+
+  /**
+   * Migrate Migration State.
+   * @param {Batch} b
+   * @param {WalletMigrationContext} ctx
+   * @returns {Promise}
+   */
+
+  async migrate(b, ctx) {
+    ctx.state.version = 1;
+  }
+
+  static info() {
+    return {
+      name: 'Migrate Migration State',
+      description: 'Migrate migration state to v1'
+    };
+  }
+}
+
 /**
  * Wallet migration results.
  * @alias module:blockchain.WalletMigrationResult
@@ -1489,7 +1535,8 @@ WalletMigrator.migrations = {
   2: MigrateAccountLookahead,
   3: MigrateTXDBBalances,
   4: MigrateBidRevealEntries,
-  5: MigrateTXCountTimeIndex
+  5: MigrateTXCountTimeIndex,
+  6: MigrateMigrationStateV1
 };
 
 // Expose migrations
@@ -1499,5 +1546,6 @@ WalletMigrator.MigrateAccountLookahead = MigrateAccountLookahead;
 WalletMigrator.MigrateTXDBBalances = MigrateTXDBBalances;
 WalletMigrator.MigrateBidRevealEntries = MigrateBidRevealEntries;
 WalletMigrator.MigrateTXCountTimeIndex = MigrateTXCountTimeIndex;
+WalletMigrator.MigrateMigrationStateV1 = MigrateMigrationStateV1;
 
 module.exports = WalletMigrator;

--- a/test/data/migrations/chain-4-migrationstate-v1.json
+++ b/test/data/migrations/chain-4-migrationstate-v1.json
@@ -1,0 +1,9 @@
+{
+  "description": "Migration state update",
+  "before": {
+    "4d": "000000000000"
+  },
+  "after": {
+    "4d": "00000100010000"
+  }
+}

--- a/test/data/migrations/wallet-6-migrationstate-v1.json
+++ b/test/data/migrations/wallet-6-migrationstate-v1.json
@@ -1,0 +1,9 @@
+{
+  "description": "Migration state update",
+  "before": {
+    "4d": "000000000000"
+  },
+  "after": {
+    "4d": "00000100010000"
+  }
+}

--- a/test/migrations-test.js
+++ b/test/migrations-test.js
@@ -164,11 +164,15 @@ describe('Migrations', function() {
       });
 
       const error = migrationError(migrations, [1], DB_FLAG_ERROR);
-      await assert.rejects(async () => {
+      let err;
+      try {
         await db.open();
-      }, {
-        message: error
-      });
+      } catch (e) {
+        err = e;
+      }
+
+      assert(err);
+      assert.strictEqual(err.message, error);
     });
   });
 

--- a/test/util/migrations.js
+++ b/test/util/migrations.js
@@ -58,19 +58,19 @@ class MockChainDB {
 
     this.spv = this.options.spv;
     this.prune = this.options.prune;
-
-    // This is here for testing purposes.
-    this.migrations = new MockChainDBMigrator({
-      ...this.options,
-      db: this,
-      dbVersion: this.dbVersion
-    });
   }
 
   async open() {
     this.logger.debug('Opening mock chaindb.');
     await this.db.open();
-    await this.migrations.migrate();
+    // This is here for testing purposes.
+    const migrations = new MockChainDBMigrator({
+      ...this.options,
+      db: this,
+      dbVersion: this.dbVersion
+    });
+
+    await migrations.migrate();
     await this.db.verify(mockLayout.V.encode(), 'chain', this.dbVersion);
   }
 


### PR DESCRIPTION
Add in progress arbitrary data storage to the migrations. Long running processes may be interrupted and may not have simple way to recover last state. This should allow those migrations to store metadata to the db.

- Add version entry to the migration state. Repurpose unused 16 bits of flags into the version, that should allow conditional serialization of the migration state.
- Create and pass the migration context to the migrations instead of just passing Results.
- Migration context now contains state that will get committed after the migration is done, but also provides saveState for the data.

- [x] Add migration to the chain/wallet to increment migration state version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users upgrading to the latest version must now include the command-line options `--chain-migrate=4` and `--wallet-migrate=6` on the first run.
  - Enhanced migration framework introduces structured context handling for migration states.
  - New migration classes and methods improve clarity and consistency in migration processes.

- **Bug Fixes**
  - Improved error handling and clarity in migration tests.

- **Tests**
  - Added new test suites and cases to validate migration processes for both chain and wallet migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->