### PR TITLE
Nb abort

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
+        node: [16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -70,12 +70,6 @@ jobs:
     - name: Install libunbound
       if: contains(matrix.os, 'ubuntu')
       run: sudo apt-get update && sudo apt-get install -y libunbound-dev
-
-    # Pythong 3.10->3.11 broke node-gyp. This upgrades node-gyp for older nodejs.
-    # https://github.com/nodejs/node-gyp/issues/2219
-    - name: Update npm.
-      if: contains(matrix.node, '14.x')
-      run: npm i -g npm@9
 
     - name: Install dependencies
       run: npm install

--- a/lib/client/wallet.js
+++ b/lib/client/wallet.js
@@ -686,6 +686,32 @@ class WalletClient extends bcurl.Client {
   }
 
   /**
+   * Get receive address. (UNSAFE)
+   * @param {String} id
+   * @param {String} account
+   * @param {Number} index
+   * @param {Boolean} safe
+   * @returns {Promise}
+   */
+
+  getAddress(id, account, index, safe) {
+    return this.get(`/wallet/${id}/address`, { account, index, safe });
+  }
+
+  /**
+   * Get change address. (UNSAFE)
+   * @param {String} id
+   * @param {String} account
+   * @param {Number} index
+   * @param {Boolean} safe
+   * @returns {Promise}
+   */
+
+  getChange(id, account, index, safe) {
+    return this.get(`/wallet/${id}/change`, { account, index, safe });
+  }
+
+  /**
    * Create address.
    * @param {Object} options
    * @returns {Promise}
@@ -1372,6 +1398,30 @@ class Wallet extends EventEmitter {
 
   modifyAccount(name, options) {
     return this.client.modifyAccount(this.id, name, options);
+  }
+
+  /**
+   * Get receive address. (UNSAFE)
+   * @param {String} account
+   * @param {Number} index
+   * @param {Boolean} safe
+   * @returns {Promise}
+   */
+
+  getAddress(account, index, safe) {
+    return this.client.getAddress(this.id, account, index, safe);
+  }
+
+  /**
+   * Get change address. (UNSAFE)
+   * @param {String} account
+   * @param {Number} index
+   * @param {Boolean} safe
+   * @returns {Promise}
+   */
+
+  getChange(account, index, safe) {
+    return this.client.getChange(this.id, account, index, safe);
   }
 
   /**

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -255,6 +255,9 @@ class RPC extends RPCBase {
     // this.add('getnameinfo', this.getNameInfo);
     // this.add('getnameresource', this.getNameResource);
     // this.add('getnameproof', this.getNameProof);
+
+    // Namebase specific events.
+    this.add('emitnamebaseevent', this.emitNamebaseEvent);
   }
 
   /*
@@ -2630,6 +2633,18 @@ class RPC extends RPCBase {
       return null;
 
     this.node.ns.resetCache();
+
+    return null;
+  }
+
+  async emitNamebaseEvent(args) {
+    if (args.length < 1)
+      throw new RPCError(errs.MISC_ERROR, 'emitnamebaseevent ( ...args )');
+
+    const valid = new Validator(args);
+    const eventName = valid.str(0);
+
+    this.emit(`namebase-${eventName}`, args.slice(1));
 
     return null;
   }

--- a/lib/wallet/account.js
+++ b/lib/wallet/account.js
@@ -437,6 +437,39 @@ class Account extends bio.Struct {
 
   /**
    * Derive an address at `index`. Do not increment depth.
+   * Optionally check safety.
+   * @param {Number} branch
+   * @param {Number} index
+   * @param {Boolean} [safe]
+   * @param {MasterKey} [master]
+   * @returns {WalletKey}
+   */
+
+  deriveCheckedKey(branch, index, safe, master) {
+    assert(typeof branch === 'number');
+
+    if (safe) {
+      switch (branch) {
+        case 0: {
+          if (index > this.receiveDepth + this.lookahead)
+            throw new Error('Receive index out of bounds.');
+
+          break;
+        }
+        case 1: {
+          if (index > this.changeDepth + this.lookahead)
+            throw new Error('Change index out of bounds.');
+
+          break;
+        }
+      }
+    }
+
+    return this.deriveKey(branch, index, master);
+  }
+
+  /**
+   * Derive an address at `index`. Do not increment depth.
    * @param {Number} branch
    * @param {Number} index
    * @param {MasterKey} [master]

--- a/lib/wallet/common.js
+++ b/lib/wallet/common.js
@@ -162,3 +162,15 @@ common.coinSelectionTypes = {
   DB_SWEEPDUST: 'db-sweepdust',
   DB_AGE: 'db-age'
 };
+
+common.AbortError = class AbortError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = 'AbortError';
+    this.message = message || 'Operation aborted.';
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, common.AbortError);
+    }
+  }
+};

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -646,6 +646,28 @@ class HTTP extends Server {
       res.json(200, { privateKey: key.toSecret(this.network) });
     });
 
+    // Get address
+    this.get('/wallet/:id/address', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const acct = valid.str('account');
+      const index = valid.u32('index');
+      const safe = valid.bool('safe', false);
+      const addr = await req.wallet.deriveReceive(acct, index, safe);
+
+      res.json(200, addr.getJSON(this.network));
+    });
+
+    // Get change address
+    this.get('/wallet/:id/change', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const acct = valid.str('account');
+      const index = valid.u32('index');
+      const safe = valid.bool('safe', false);
+      const addr = await req.wallet.deriveChange(acct, index, safe);
+
+      res.json(200, addr.getJSON(this.network));
+    });
+
     // Create address
     this.post('/wallet/:id/address', async (req, res) => {
       const valid = Validator.fromRequest(req);

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -103,6 +103,14 @@ class HTTP extends Server {
     }));
 
     this.use(async (req, res) => {
+      res.abortController = new AbortController();
+
+      res.on('close', () => {
+        res.abortController.abort(new Error('Client closed connection.'));
+      });
+    });
+
+    this.use(async (req, res) => {
       if (!this.options.walletAuth) {
         req.admin = true;
         return;
@@ -479,7 +487,8 @@ class HTTP extends Server {
     this.post('/wallet/:id/send', async (req, res) => {
       const valid = Validator.fromRequest(req);
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
       const tx = await req.wallet.send(options);
 
       const details = await req.wallet.getDetails(tx.hash());
@@ -494,7 +503,8 @@ class HTTP extends Server {
 
       // TODO: Add create TX with locks for used Coins and/or
       // adds to the pending list.
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
       const tx = await req.wallet.createTX(options);
 
       if (sign)
@@ -1133,7 +1143,8 @@ class HTTP extends Server {
       enforce(name, 'Name is required.');
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       if (broadcast) {
         // TODO: Add abort signal to close when request closes.
@@ -1170,7 +1181,8 @@ class HTTP extends Server {
       enforce(lockup != null, 'Lockup is required.');
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       if (broadcast) {
         // TODO: Add abort signal to close when request closes.
@@ -1209,7 +1221,8 @@ class HTTP extends Server {
       enforce(broadcastBid != null, 'broadcastBid is required.');
       enforce(broadcastBid ? sign : true, 'Must sign when broadcasting.');
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
       const auctionTXs = await req.wallet.createAuctionTXs(
         name,
         bid,
@@ -1250,7 +1263,8 @@ class HTTP extends Server {
 
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       if (broadcast) {
         let tx;
@@ -1296,7 +1310,8 @@ class HTTP extends Server {
 
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       if (broadcast) {
         let tx;
@@ -1352,7 +1367,8 @@ class HTTP extends Server {
         return res.json(400);
       }
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       const rawResource = resource.encode();
 
@@ -1387,7 +1403,8 @@ class HTTP extends Server {
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
       enforce(name, 'Must pass name.');
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       if (broadcast) {
         // TODO: Add abort signal to close when request closes.
@@ -1421,7 +1438,8 @@ class HTTP extends Server {
       enforce(address, 'Must pass address.');
 
       const addr = Address.fromString(address, this.network);
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       if (broadcast) {
         // TODO: Add abort signal to close when request closes.
@@ -1454,7 +1472,8 @@ class HTTP extends Server {
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
       enforce(name, 'Must pass name.');
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       if (broadcast) {
         // TODO: Add abort signal to close when request closes.
@@ -1487,7 +1506,8 @@ class HTTP extends Server {
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
       enforce(name, 'Must pass name.');
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       if (broadcast) {
         // TODO: Add abort signal to close when request closes.
@@ -1518,7 +1538,8 @@ class HTTP extends Server {
       enforce(broadcast ? sign : true, 'Must sign when broadcasting.');
       enforce(name, 'Must pass name.');
 
-      const options = TransactionOptions.fromValidator(valid, this.network);
+      const options = TransactionOptions.fromValidator(valid, this.network,
+        res.abortController.signal);
 
       if (broadcast) {
         // TODO: Add abort signal to close when request closes.
@@ -1887,11 +1908,12 @@ class TransactionOptions {
    * @constructor
    * @param {RequestValidator} [valid]
    * @param {(NetworkType|Network)?} [network]
+   * @param {AbortSignal} [signal]
    */
 
-  constructor(valid, network) {
+  constructor(valid, network, signal) {
     if (valid)
-      return this.fromValidator(valid, network);
+      return this.fromValidator(valid, network, signal);
   }
 
   /**
@@ -1899,10 +1921,11 @@ class TransactionOptions {
    * @private
    * @param {RequestValidator} valid
    * @param {(NetworkType|Network)?} [network]
+   * @param {AbortSignal} [signal]
    * @returns {TransactionOptions}
    */
 
-  fromValidator(valid, network) {
+  fromValidator(valid, network, signal) {
     assert(valid);
 
     this.rate = valid.u64('rate');
@@ -1920,7 +1943,15 @@ class TransactionOptions {
     this.passphrase = valid.str('passphrase');
     this.hardFee = valid.u64('hardFee'),
     this.blocks = valid.u32('blocks');
+    this.dontSendOnClose = valid.bool('dontSendOnClose', false);
+    this.network = network || Network.primary;
+    this.signal = null;
     this.outputs = [];
+
+    if (this.dontSendOnClose) {
+      assert(signal);
+      this.signal = signal;
+    }
 
     if (valid.has('outputs')) {
       const outputs = valid.array('outputs');
@@ -1955,11 +1986,12 @@ class TransactionOptions {
    * from Validator.
    * @param {RequestValidator} [valid]
    * @param {(NetworkType|Network)?} [network]
+   * @param {AbortSignal} [signal]
    * @returns {TransactionOptions}
    */
 
-  static fromValidator(valid, network) {
-    return new this().fromValidator(valid, network);
+  static fromValidator(valid, network, signal) {
+    return new this().fromValidator(valid, network, signal);
   }
 }
 

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1943,12 +1943,12 @@ class TransactionOptions {
     this.passphrase = valid.str('passphrase');
     this.hardFee = valid.u64('hardFee'),
     this.blocks = valid.u32('blocks');
-    this.dontSendOnClose = valid.bool('dontSendOnClose', false);
+    this.abortOnClose = valid.bool('abortOnClose', false);
     this.network = network || Network.primary;
     this.signal = null;
     this.outputs = [];
 
-    if (this.dontSendOnClose) {
+    if (this.abortOnClose) {
       assert(signal);
       this.signal = signal;
     }

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -1326,15 +1326,17 @@ class HTTP extends Server {
 
       const options = TransactionOptions.fromValidator(valid, this.network);
 
+      const rawResource = resource.encode();
+
       if (broadcast) {
         // TODO: Add abort signal to close when request closes.
-        const tx = await req.wallet.sendUpdate(name, resource, options);
+        const tx = await req.wallet.sendUpdate(name, rawResource, options);
         return res.json(200, tx.getJSON(this.network));
       }
 
       // TODO: Add create TX with locks for used Coins and/or
       // adds to the pending list.
-      const mtx = await req.wallet.createUpdate(name, resource, options);
+      const mtx = await req.wallet.createUpdate(name, rawResource, options);
 
       if (sign)
         await req.wallet.sign(mtx, options.passphrase);

--- a/lib/wallet/http.js
+++ b/lib/wallet/http.js
@@ -652,6 +652,9 @@ class HTTP extends Server {
       const acct = valid.str('account');
       const index = valid.u32('index');
       const safe = valid.bool('safe', false);
+
+      enforce(index != null, 'Index is required.');
+
       const addr = await req.wallet.deriveReceive(acct, index, safe);
 
       res.json(200, addr.getJSON(this.network));
@@ -663,6 +666,9 @@ class HTTP extends Server {
       const acct = valid.str('account');
       const index = valid.u32('index');
       const safe = valid.bool('safe', false);
+
+      enforce(index != null, 'Index is required.');
+
       const addr = await req.wallet.deriveChange(acct, index, safe);
 
       res.json(200, addr.getJSON(this.network));

--- a/lib/wallet/rpc.js
+++ b/lib/wallet/rpc.js
@@ -2487,7 +2487,8 @@ class RPC extends RPCBase {
   async sendUpdate(args, help) {
     const opts = this._validateUpdate(args, help, 'sendupdate');
     const wallet = this.wallet;
-    const tx = await wallet.sendUpdate(opts.name, opts.resource, {
+    const rawResource = opts.resource.encode();
+    const tx = await wallet.sendUpdate(opts.name, rawResource, {
       account: opts.account
     });
 
@@ -2497,7 +2498,8 @@ class RPC extends RPCBase {
   async createUpdate(args, help) {
     const opts = this._validateUpdate(args, help, 'createupdate');
     const wallet = this.wallet;
-    const mtx = await wallet.createUpdate(opts.name, opts.resource, {
+    const rawResource = opts.resource.encode();
+    const mtx = await wallet.createUpdate(opts.name, rawResource, {
       paths: true,
       account: opts.account
     });
@@ -2813,7 +2815,8 @@ class RPC extends RPCBase {
             'UPDATE action requires 2 arguments: name, data'
           );
           const {name, resource} = this._validateUpdate(action);
-          actions.push({ type: type, args: [name, resource] });
+          const rawResource = resource.encode();
+          actions.push({ type: type, args: [name, rawResource] });
           break;
         }
         case 'RENEW': {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -883,6 +883,48 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Derive a receiving address (does not increment receiveDepth).
+   * @param {(Number|String)?} acct
+   * @param {Number} index
+   * @param {Boolean} [safe]
+   * @returns {Promise<WalletKey>}
+   */
+
+  deriveReceive(acct = 0, index, safe) {
+    return this.deriveKey(acct, 0, index, safe);
+  }
+
+  /**
+   * Derive a change address (does not increment changeDepth).
+   * @param {(Number|String)?} acct
+   * @param {Number} index
+   * @param {Boolean} [safe]
+   * @returns {Promise<WalletKey>}
+   */
+
+  deriveChange(acct = 0, index, safe) {
+    return this.deriveKey(acct, 1, index, safe);
+  }
+
+  /**
+   * Derive address (does not increment depth).
+   * @param {(Number|String)?} acct
+   * @param {Number} branch
+   * @param {Number} index
+   * @param {Boolean} safe
+   * @returns {Promise<WalletKey>}
+   */
+
+  async deriveKey(acct = 0, branch, index, safe) {
+    const account = await this.getAccount(acct);
+
+    if (!account)
+      throw new Error('Account not found.');
+
+    return account.deriveCheckedKey(branch, index, safe);
+  }
+
+  /**
    * Create a new receiving address (increments receiveDepth).
    * @param {(Number|String)?} acct
    * @returns {Promise<WalletKey>}

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1313,7 +1313,8 @@ class Wallet extends EventEmitter {
       coinbaseMaturity: this.network.coinbaseMaturity,
       rate: rate,
       maxFee: options.maxFee,
-      estimate: prev => this.estimateSize(prev)
+      estimate: prev => this.estimateSize(prev),
+      signal: options.signal
     });
 
     mtx.fill(selected);
@@ -5826,6 +5827,7 @@ class WalletCoinSource extends AbstractCoinSource {
     this.smart = false;
 
     this.sweepdustMinValue = 1;
+    this.signal = null;
 
     if (options)
       this.fromOptions(options);
@@ -5858,6 +5860,12 @@ class WalletCoinSource extends AbstractCoinSource {
         'Sweepdust min value must be a uint32.');
 
       this.sweepdustMinValue = options.sweepdustMinValue;
+    }
+
+    if (options.signal != null) {
+      assert(typeof options.signal === 'object',
+        'Signal must be an AbortSignal.');
+      this.signal = options.signal;
     }
 
     return this;
@@ -5904,6 +5912,11 @@ class WalletCoinSource extends AbstractCoinSource {
     if (this.done)
       return null;
 
+    if (this.signal && this.signal.aborted) {
+      this.done = true;
+      return this.iter.throw(new Error('Coin selection aborted.'));
+    }
+
     // look for an usable credit.
     for (;;) {
       const item = await this.iter.next();
@@ -5935,7 +5948,7 @@ class WalletCoinSource extends AbstractCoinSource {
     if (!this.iter)
       return;
 
-    this.iter.return();
+    await this.iter.return();
   }
 
   /**

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1862,8 +1862,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createOpen(name, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -1996,8 +1995,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createBid(name, value, lockup, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -2226,8 +2224,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createReveal(name, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -2364,8 +2361,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRevealAll(options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -2512,8 +2508,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRedeem(name, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -2647,8 +2642,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRedeemAll(options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -2880,8 +2874,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createUpdate(name, rawResource, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -3111,8 +3104,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRenewal(name, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -3266,8 +3258,7 @@ class Wallet extends EventEmitter {
       options
     );
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -3402,8 +3393,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createCancel(name, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -3640,8 +3630,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createFinalize(name, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -3785,8 +3774,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRevoke(name, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -4260,8 +4248,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const {mtx, errors} = await this._createBatch(actions, options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return {
       tx: await this.sendMTX(mtx, passphrase),
@@ -4380,8 +4367,7 @@ class Wallet extends EventEmitter {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createTX(options);
 
-    if (options && options.signal)
-      options.signal.throwIfAborted();
+    checkSendAbort(options);
 
     return this.sendMTX(mtx, passphrase);
   }
@@ -5914,7 +5900,10 @@ class WalletCoinSource extends AbstractCoinSource {
 
     if (this.signal && this.signal.aborted) {
       this.done = true;
-      return this.iter.throw(new Error('Coin selection aborted.'));
+
+      const error = new common.AbortError('Coin selection aborted.',
+        { cause: this.signal.reason });
+      return this.iter.throw(error);
     }
 
     // look for an usable credit.
@@ -5985,6 +5974,21 @@ class WalletCoinSource extends AbstractCoinSource {
       inputs.delete(key);
     }
   }
+}
+
+/*
+ * Helpers
+ */
+
+function checkSendAbort(options) {
+  if (!options || !options.signal)
+    return;
+
+  if (!options.signal.aborted)
+    return;
+
+  throw new common.AbortError('Send was aborted.',
+    { cause: options.signal.reason });
 }
 
 /*

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -1860,6 +1860,10 @@ class Wallet extends EventEmitter {
   async _sendOpen(name, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createOpen(name, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -1990,6 +1994,10 @@ class Wallet extends EventEmitter {
   async _sendBid(name, value, lockup, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createBid(name, value, lockup, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2216,6 +2224,10 @@ class Wallet extends EventEmitter {
   async _sendReveal(name, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createReveal(name, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2350,6 +2362,10 @@ class Wallet extends EventEmitter {
   async _sendRevealAll(options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRevealAll(options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2494,6 +2510,10 @@ class Wallet extends EventEmitter {
   async _sendRedeem(name, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRedeem(name, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2625,6 +2645,10 @@ class Wallet extends EventEmitter {
   async _sendRedeemAll(options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRedeemAll(options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2854,6 +2878,10 @@ class Wallet extends EventEmitter {
   async _sendUpdate(name, rawResource, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createUpdate(name, rawResource, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -3081,6 +3109,10 @@ class Wallet extends EventEmitter {
   async _sendRenewal(name, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRenewal(name, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -3232,6 +3264,10 @@ class Wallet extends EventEmitter {
       address,
       options
     );
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -3364,6 +3400,10 @@ class Wallet extends EventEmitter {
   async _sendCancel(name, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createCancel(name, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -3598,6 +3638,10 @@ class Wallet extends EventEmitter {
   async _sendFinalize(name, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createFinalize(name, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -3739,6 +3783,10 @@ class Wallet extends EventEmitter {
   async _sendRevoke(name, options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createRevoke(name, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -4210,6 +4258,10 @@ class Wallet extends EventEmitter {
   async _sendBatch(actions, options) {
     const passphrase = options ? options.passphrase : null;
     const {mtx, errors} = await this._createBatch(actions, options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return {
       tx: await this.sendMTX(mtx, passphrase),
       errors
@@ -4326,6 +4378,10 @@ class Wallet extends EventEmitter {
   async _send(options) {
     const passphrase = options ? options.passphrase : null;
     const mtx = await this._createTX(options);
+
+    if (options && options.signal)
+      options.signal.throwIfAborted();
+
     return this.sendMTX(mtx, passphrase);
   }
 

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -34,7 +34,6 @@ const MasterKey = require('./masterkey');
 const policy = require('../protocol/policy');
 const consensus = require('../protocol/consensus');
 const rules = require('../covenants/rules');
-const {Resource} = require('../dns/resource');
 const Claim = require('../primitives/claim');
 const reserved = require('../covenants/reserved');
 const {ownership} = require('../covenants/ownership');
@@ -2607,14 +2606,14 @@ class Wallet extends EventEmitter {
    * Make a register MTX.
    * @private
    * @param {String} name
-   * @param {Resource?} resource
+   * @param {Buffer?} rawResource
    * @param {MTX?} [mtx]
    * @returns {Promise<MTX>}
    */
 
-  async _makeRegister(name, resource, mtx) {
+  async _makeRegister(name, rawResource, mtx) {
     assert(typeof name === 'string');
-    assert(!resource || (resource instanceof Resource));
+    assert(!rawResource || Buffer.isBuffer(rawResource));
 
     if (!rules.verifyName(name))
       throw new Error(`Invalid name: ${name}.`);
@@ -2661,18 +2660,11 @@ class Wallet extends EventEmitter {
     output.address = coin.address;
     output.value = ns.value;
 
-    let rawResource = EMPTY;
-
-    if (resource) {
-      const raw = resource.encode();
-
-      if (raw.length > rules.MAX_RESOURCE_SIZE)
+    if (rawResource && rawResource.length > rules.MAX_RESOURCE_SIZE) {
         throw new Error(
-          `Resource size (${raw.length}) exceeds maximum `+
+          `Resource size (${rawResource.length}) exceeds maximum `+
           `(${rules.MAX_RESOURCE_SIZE}) for name: ${name}.`
         );
-
-      rawResource = raw;
     }
 
     const blockHash = await this.wdb.getRenewalBlock();
@@ -2690,15 +2682,15 @@ class Wallet extends EventEmitter {
   /**
    * Make an update MTX.
    * @param {String} name
-   * @param {Resource} resource
+   * @param {Buffer} rawResource
    * @param {(Number|String)?} acct
    * @param {MTX?} [mtx]
    * @returns {Promise<MTX>}
    */
 
-  async makeUpdate(name, resource, acct, mtx) {
+  async makeUpdate(name, rawResource, acct, mtx) {
     assert(typeof name === 'string');
-    assert(resource instanceof Resource);
+    assert(Buffer.isBuffer(rawResource));
 
     if (!rules.verifyName(name))
       throw new Error('Invalid name.');
@@ -2736,7 +2728,7 @@ class Wallet extends EventEmitter {
     const coin = credit.coin;
 
     if (coin.covenant.isReveal() || coin.covenant.isClaim())
-      return this._makeRegister(name, resource, mtx);
+      return this._makeRegister(name, rawResource, mtx);
 
     if (ns.isExpired(height, network))
       throw new Error(`Name has expired: ${name}.`);
@@ -2755,15 +2747,13 @@ class Wallet extends EventEmitter {
       throw new Error(`Name is not registered: ${name}.`);
     }
 
-    const raw = resource.encode();
-
-    if (raw.length > rules.MAX_RESOURCE_SIZE)
+    if (rawResource.length > rules.MAX_RESOURCE_SIZE)
       throw new Error(`Resource exceeds maximum size: ${name}.`);
 
     const output = new Output();
     output.address = coin.address;
     output.value = coin.value;
-    output.covenant.setUpdate(nameHash, ns.height, raw);
+    output.covenant.setUpdate(nameHash, ns.height, rawResource);
 
     if (!mtx)
       mtx = new MTX();
@@ -2777,14 +2767,14 @@ class Wallet extends EventEmitter {
    * Create and finalize an update
    * MTX without a lock.
    * @param {String} name
-   * @param {Resource} resource
+   * @param {Buffer} rawResource
    * @param {Object} options
    * @returns {Promise<MTX>}
    */
 
-  async _createUpdate(name, resource, options) {
+  async _createUpdate(name, rawResource, options) {
     const acct = options ? options.account : null;
-    const mtx = await this.makeUpdate(name, resource, acct);
+    const mtx = await this.makeUpdate(name, rawResource, acct);
     await this.fill(mtx, options);
     return this.finalize(mtx, options);
   }
@@ -2811,14 +2801,14 @@ class Wallet extends EventEmitter {
    * Create and send an update
    * MTX without a lock.
    * @param {String} name
-   * @param {Resource} resource
+   * @param {Buffer} rawResource
    * @param {Object} options
    * @returns {Promise<TX>}
    */
 
-  async _sendUpdate(name, resource, options) {
+  async _sendUpdate(name, rawResource, options) {
     const passphrase = options ? options.passphrase : null;
-    const mtx = await this._createUpdate(name, resource, options);
+    const mtx = await this._createUpdate(name, rawResource, options);
     return this.sendMTX(mtx, passphrase);
   }
 
@@ -2826,15 +2816,15 @@ class Wallet extends EventEmitter {
    * Create and send an update
    * MTX with a lock.
    * @param {String} name
-   * @param {Resource} resource
+   * @param {Buffer} rawResource
    * @param {Object} options
    * @returns {Promise<TX>}
    */
 
-  async sendUpdate(name, resource, options) {
+  async sendUpdate(name, rawResource, options) {
     const unlock = await this.fundLock.lock();
     try {
-      return await this._sendUpdate(name, resource, options);
+      return await this._sendUpdate(name, rawResource, options);
     } finally {
       unlock();
     }
@@ -4003,8 +3993,8 @@ class Wallet extends EventEmitter {
         case 'UPDATE': {
           assert(args.length === 2, 'Bad arguments for UPDATE.');
           const name = args[0];
-          const resource = args[1];
-          await this.makeUpdate(name, resource, acct, mtx);
+          const rawResource = args[1];
+          await this.makeUpdate(name, rawResource, acct, mtx);
           break;
         }
         case 'RENEW': {

--- a/lib/wallet/wallet.js
+++ b/lib/wallet/wallet.js
@@ -2660,7 +2660,10 @@ class Wallet extends EventEmitter {
     output.address = coin.address;
     output.value = ns.value;
 
-    if (rawResource && rawResource.length > rules.MAX_RESOURCE_SIZE) {
+    if (!rawResource)
+      rawResource = EMPTY;
+
+    if (rawResource.length > rules.MAX_RESOURCE_SIZE) {
         throw new Error(
           `Resource size (${rawResource.length}) exceeds maximum `+
           `(${rules.MAX_RESOURCE_SIZE}) for name: ${name}.`

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "bslintrc": "^0.0.3"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.14.0"
       }
     },
     "node_modules/bcfg": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hsd",
-  "version": "8.99.0",
+  "version": "8.0.0-nb.0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hsd",
-      "version": "8.99.0",
+      "version": "8.0.0-nb.0.0.0",
       "license": "MIT",
       "dependencies": {
         "bcfg": "~0.2.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "wallet"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.14.0"
   },
   "dependencies": {
     "bfilter": "~2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hsd",
-  "version": "8.99.0",
+  "version": "8.0.0-nb.0.0.0",
   "description": "Cryptocurrency bike-shed",
   "license": "MIT",
   "repository": "git://github.com/handshake-org/hsd.git",

--- a/test/anyone-can-renew-test.js
+++ b/test/anyone-can-renew-test.js
@@ -127,7 +127,7 @@ describe('Anyone-can-renew address', function() {
     const resource = Resource.fromJSON({
       records: [{type: 'TXT', txt: ['This name is ANYONE-CAN-RENEW']}]
     });
-    await alice.sendUpdate(name, resource);
+    await alice.sendUpdate(name, resource.encode());
     await mineBlocks(network.names.treeInterval);
 
     ns = await node.getNameStatus(nameHash);

--- a/test/claim-test.js
+++ b/test/claim-test.js
@@ -167,7 +167,7 @@ describe('Reserved Name Claims', function() {
     const resource = Resource.fromJSON({
       records: [{type: 'TXT', txt: ['#CooperationGood']}]
     });
-    const register = await wallet.sendUpdate('cloudflare', resource);
+    const register = await wallet.sendUpdate('cloudflare', resource.encode());
     check();
     await mineBlocks(1);
     check();

--- a/test/interactive-swap-test.js
+++ b/test/interactive-swap-test.js
@@ -113,7 +113,7 @@ describe('Interactive name swap', function() {
     const resource = Resource.fromJSON({
       records: [{type: 'TXT', txt: ['Contact Alice to buy this name!']}]
     });
-    await alice.sendUpdate(name, resource);
+    await alice.sendUpdate(name, resource.encode());
     await mineBlocks(network.names.treeInterval);
   });
 
@@ -292,7 +292,7 @@ describe('Interactive name swap', function() {
     const resource = Resource.fromJSON({
       records: [{type: 'TXT', txt: ['Thanks Alice! --Bob']}]
     });
-    await bob.sendUpdate(name, resource);
+    await bob.sendUpdate(name, resource.encode());
     await mineBlocks(network.names.treeInterval);
     const actual = await node.chain.db.getNameState(nameHash);
     assert.bufferEqual(resource.encode(), actual.data);

--- a/test/mempool-invalidation-test.js
+++ b/test/mempool-invalidation-test.js
@@ -321,7 +321,8 @@ describe('Mempool Invalidation', function() {
 
       assert.strictEqual(await getNameState(name), states.CLOSED);
 
-      await wallet.sendUpdate(name, Resource.fromJSON({ records: [] }));
+      const res = Resource.fromJSON({ records: [] });
+      await wallet.sendUpdate(name, res.encode());
 
       for (let i = 0; i < network.names.renewalWindow - 2; i++)
         await mineBlock(node);

--- a/test/mempool-reorg-test.js
+++ b/test/mempool-reorg-test.js
@@ -41,9 +41,11 @@ describe('Mempool Covenant Reorg', function () {
 
   let counter = 0;
   function makeResource() {
-    return Resource.fromJSON({
+    const res =  Resource.fromJSON({
       records: [{type: 'TXT', txt: [`${counter++}`]}]
     });
+
+    return res.encode();
   }
 
   it('should fund wallet and win name', async () => {

--- a/test/net-spv-test.js
+++ b/test/net-spv-test.js
@@ -122,16 +122,13 @@ describe('SPV', function() {
       await mineBlocks(biddingPeriod);
       await wallet.sendReveal(name);
       await mineBlocks(revealPeriod);
-      await wallet.sendUpdate(
-        name,
-        Resource.fromJSON(
-          {
-            records: [
-              {type: 'NS', ns: 'one.'}
-            ]
-          }
-        )
-      );
+      const res = Resource.fromJSON({
+        records: [
+          {type: 'NS', ns: 'one.'}
+        ]
+      });
+
+      await wallet.sendUpdate(name, res.encode());
       await mineBlocks(treeInterval + SAFE_ROOT);
     });
 
@@ -166,16 +163,13 @@ describe('SPV', function() {
     });
 
     it('should update name data', async () => {
-      await wallet.sendUpdate(
-        name,
-        Resource.fromJSON(
-          {
-            records: [
-              {type: 'NS', ns: 'two.'}
-            ]
-          }
-        )
-      );
+      const res = Resource.fromJSON({
+        records: [
+          {type: 'NS', ns: 'two.'}
+        ]
+      });
+
+      await wallet.sendUpdate(name, res.encode());
       await mineBlocks(treeInterval + SAFE_ROOT);
     });
 

--- a/test/util/common.js
+++ b/test/util/common.js
@@ -244,7 +244,7 @@ common.delayMethodOnce = function delayMethodOnce(obj, prop, n) {
     await common.sleep(n);
 
     try {
-      return bak.call(obj, ...args);
+      return bak.call(this, ...args);
     } finally {
       obj[prop] = bak;
     }

--- a/test/util/common.js
+++ b/test/util/common.js
@@ -237,6 +237,20 @@ common.enableLogger = () => {
   Logger.global.closed = false;
 };
 
+common.delayMethodOnce = function delayMethodOnce(obj, prop, n) {
+  const bak = obj[prop];
+
+  obj[prop] = async function(...args) {
+    await common.sleep(n);
+
+    try {
+      return bak.call(obj, ...args);
+    } finally {
+      obj[prop] = bak;
+    }
+  };
+};
+
 function parseUndo(data) {
   const br = bio.read(data);
   const items = [];

--- a/test/util/node-context.js
+++ b/test/util/node-context.js
@@ -175,14 +175,18 @@ class NodeContext {
     return this.chain.tip.height;
   }
 
-  get wdb() {
+  get wnode() {
     if (!this.options.wallet)
       return null;
 
     if (this.walletNode)
-      return this.walletNode.wdb;
+      return this.walletNode;
 
-    return this.node.get('walletdb').wdb;
+    return this.node.get('walletdb');
+  }
+
+  get wdb() {
+    return this.wnode?.wdb;
   }
 
   /*

--- a/test/wallet-accounts-auction-test.js
+++ b/test/wallet-accounts-auction-test.js
@@ -5,7 +5,7 @@ const Network = require('../lib/protocol/network');
 const FullNode = require('../lib/node/fullnode');
 const Address = require('../lib/primitives/address');
 const rules = require('../lib/covenants/rules');
-const Resource = require('../lib/dns/resource');
+const {Resource} = require('../lib/dns/resource');
 const WalletClient = require('../lib/client/wallet');
 
 const network = Network.get('regtest');
@@ -129,20 +129,20 @@ describe('Multiple accounts participating in same auction', function() {
   });
 
   describe('UPDATE', function() {
-    const aliceResource = Resource.Resource.fromJSON({
+    const aliceResource = Resource.fromJSON({
       records: [
         {
           type: 'TXT',
           txt: ['ALICE']
         }
-      ]});
-    const bobResource = Resource.Resource.fromJSON({
+      ]}).encode();
+    const bobResource = Resource.fromJSON({
       records: [
         {
           type: 'TXT',
           txt: ['BOB']
         }
-      ]});
+      ]}).encode();
 
     it('should advance auction to REGISTER phase', async () => {
       await mineBlocks(network.names.revealPeriod);

--- a/test/wallet-auction-test.js
+++ b/test/wallet-auction-test.js
@@ -1004,6 +1004,27 @@ describe('Wallet Auction', function() {
       assert.strictEqual(mtx.outputs.length, 3);
     });
 
+    it('should not broadcast tx if client is signal is aborted', async () => {
+      let err;
+      try {
+        await wallet.sendBatch(
+          [
+            { type: 'OPEN', args: [name1] },
+            { type: 'OPEN', args: [name2] },
+            { type: 'OPEN', args: [name3] }
+          ],
+          {
+            signal: AbortSignal.abort(new Error('Aborted by user.'))
+          }
+        );
+      } catch (e) {
+        err = e;
+      }
+
+      assert(err);
+      assert.strictEqual(err.message, 'Aborted by user.');
+    });
+
     describe('Complete auction and diverse-action batches', function() {
       const addr = Address.fromProgram(0, Buffer.alloc(20, 0x01)).toString('regtest');
 

--- a/test/wallet-balance-test.js
+++ b/test/wallet-balance-test.js
@@ -112,7 +112,7 @@ const FINAL_PRICE_2 = 2e5; // less then 1e6/4 (2.5e5)
 // const BLIND_ONLY_3 = BLIND_AMOUNT_3 - BID_AMOUNT_3;
 
 // Empty resource
-const EMPTY_RS = Resource.fromJSON({ records: [] });
+const EMPTY_RS = Resource.fromJSON({ records: [] }).encode();
 
 /*
  * Wallet helpers

--- a/test/wallet-deepclean-test.js
+++ b/test/wallet-deepclean-test.js
@@ -4,7 +4,7 @@ const assert = require('bsert');
 const Network = require('../lib/protocol/network');
 const FullNode = require('../lib/node/fullnode');
 const Address = require('../lib/primitives/address');
-const Resource = require('../lib/dns/resource');
+const {Resource} = require('../lib/dns/resource');
 
 const network = Network.get('regtest');
 
@@ -93,7 +93,7 @@ describe('Wallet Deep Clean', function() {
       await w.sendReveal(name, {account: 0});
       await mineBlocks(network.names.revealPeriod);
 
-      const res = Resource.Resource.fromJSON({
+      const res = Resource.fromJSON({
         records: [
           {
             type: 'TXT',
@@ -102,7 +102,7 @@ describe('Wallet Deep Clean', function() {
         ]
       });
 
-      await w.sendUpdate(name, res, {account: 0});
+      await w.sendUpdate(name, res.encode(), {account: 0});
       await w.sendRedeem(name, {account: 0});
       await mineBlocks(network.names.treeInterval);
     }

--- a/test/wallet-http-test.js
+++ b/test/wallet-http-test.js
@@ -40,7 +40,7 @@ const delayMethod2error = {
 
   // If we delay finalize (After fill), abort
   // will happen once before we reach sendMTX.
-  'finalize': 'Client closed connection.'
+  'finalize': 'Send was aborted.'
 };
 
 describe('Wallet HTTP', function() {
@@ -645,6 +645,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -1009,6 +1011,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -1111,6 +1115,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -1425,7 +1431,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
-        await sleep(TIMEOUT_FULL);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -1523,7 +1530,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
-        await sleep(TIMEOUT_FULL);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -1899,6 +1907,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -2031,6 +2041,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -2178,6 +2190,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -2288,6 +2302,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -2436,6 +2452,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -2583,6 +2601,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);
@@ -2710,6 +2730,8 @@ describe('Wallet HTTP', function() {
 
         assert(wnodeError);
         assert.strictEqual(wnodeError.message, errorMessage);
+        assert.strictEqual(wnodeError.name, 'AbortError');
+        assert.strictEqual(wnodeError.cause.message, 'Client closed connection.');
 
         const pending = await wallet.getPending();
         assert.strictEqual(pending.length - prePending.length, 0);

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -2400,7 +2400,7 @@ describe('Wallet', function() {
       // Advance to close
       wdb.height += network.names.revealPeriod;
 
-      const resource = Resource.fromJSON({records: []});
+      const resource = Resource.fromJSON({records: []}).encode();
       const register = await wallet.sendUpdate(name, resource, {hardFee: fee});
       uTXCount++;
 
@@ -2779,7 +2779,7 @@ describe('Wallet', function() {
       // Advance to close
       wdb.height += network.names.revealPeriod;
 
-      const resource = Resource.fromJSON({records: []});
+      const resource = Resource.fromJSON({records: []}).encode();
       const register = await wallet.createUpdate(name, resource, {hardFee: fee});
 
       // Check
@@ -3174,7 +3174,7 @@ describe('Wallet', function() {
         records: [{type: 'NS', ns: 'ns1.easyhandshake.com.'}]
       });
 
-      update = await wallet.sendUpdate('cloudflare', records);
+      update = await wallet.sendUpdate('cloudflare', records.encode());
       const entry = nextEntry(wdb);
       await wdb.addBlock(entry, [update]);
 
@@ -3558,7 +3558,7 @@ describe('Wallet', function() {
 
     it('should send and confirm REGISTER', async () => {
       const resource = Resource.fromJSON({ records: [] });
-      const register = await wallet.sendUpdate(name, resource, {
+      const register = await wallet.sendUpdate(name, resource.encode(), {
         hardFee: fee
       });
       uTXCount++;


### PR DESCRIPTION
Make abort controller middleware for the wallet http server, dont send tx if the connection got closed to the http server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP wallet will cancel in-flight transactions when clients close connections; added derive/receive/change address endpoints and client helpers to fetch them.
  * Public update/send APIs now accept encoded resource payloads.
  * New RPC to emit Namebase events.

* **Bug Fixes**
  * Prevented broadcasts and coin-selection from proceeding after client disconnects/timeouts.

* **Tests**
  * Added extensive abort-on-close tests and a helper to delay methods once.

* **Chores**
  * Bumped package pre-release and raised minimum Node.js; removed Node 14 from CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->